### PR TITLE
Fix paper indexing error - resolve 'Failed to index paper' issue

### DIFF
--- a/frontend/src/services/paperService.ts
+++ b/frontend/src/services/paperService.ts
@@ -62,7 +62,7 @@ export class PaperService {
         .from('papers')
         .select('*')
         .eq('arxiv_id', arxivId)
-        .single();
+        .maybeSingle();
 
       if (error) {
         console.error('Error fetching paper:', error);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,7 @@ export interface Paper {
   publishedDate: string;
   summary?: string;
   methodology?: string;
+  wikiContent?: any;
 }
 
 // User type definition


### PR DESCRIPTION
# Fix paper indexing error - resolve "Failed to index paper" issue

## Summary

This PR fixes the "Failed to index paper. Please check the arXiv ID and try again." error that occurred when trying to add new papers to the Deep-Arxiv application. The issue was caused by two problems:

1. **TypeScript compilation errors**: The `wikiContent` property was missing from the `Paper` interface but was being used in the `paperService`, causing compilation failures
2. **Database query errors**: The `getPaperByArxivId` method was using `.single()` which throws a PGRST116 error when no paper is found (expects exactly one result, gets zero)

**Changes made:**
- Added `wikiContent?: any;` property to the `Paper` interface in `frontend/src/types.ts`
- Changed `.single()` to `.maybeSingle()` in the `getPaperByArxivId` method in `frontend/src/services/paperService.ts`

## Review & Testing Checklist for Human

⚠️ **Critical** - This PR requires thorough testing as database query methods were changed and only limited testing was performed during development.

- [ ] **Test full paper indexing flow with a new paper** - Try indexing an arXiv paper that doesn't exist in the database yet (e.g., a very recent paper or uncommon ID) to verify the complete flow works
- [ ] **Verify existing functionality** - Confirm that searching, displaying, and interacting with existing papers still works correctly
- [ ] **Test edge cases** - Try invalid arXiv IDs, malformed inputs, and network errors to ensure proper error handling
- [ ] **Check TypeScript compilation** - Verify that `npm run build` or equivalent passes without TypeScript errors
- [ ] **Verify no regressions** - Test that the "Paper already exists" message still shows correctly for duplicate papers

**Recommended test plan:**
1. Start the dev server and navigate to the application
2. Click "Add paper" and try indexing a recent arXiv paper (2024.XXXXX format)
3. Try indexing the same paper again to verify duplicate detection
4. Test with an invalid arXiv ID to confirm error handling
5. Search and browse existing papers to ensure no regressions

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["frontend/src/App.tsx"]:::context --> B["Add Paper Modal"]:::context
    B --> C["frontend/src/services/<br/>paperService.ts"]:::major-edit
    C --> D["getPaperByArxivId()<br/>(changed .single() to .maybeSingle())"]:::major-edit
    C --> E["indexPaper()"]:::context
    D --> F["Supabase Database"]:::context
    E --> F
    C --> G["frontend/src/types.ts"]:::major-edit
    G --> H["Paper Interface<br/>(added wikiContent property)"]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Concurrent changes**: The user also updated Supabase credentials during this session, so both the code fixes and credential updates contributed to resolving the issue
- **Type safety concern**: The `wikiContent` property uses `any` type which could be improved with a more specific interface in future iterations
- **Testing limitation**: Local testing confirmed the Supabase connection works and existing paper detection functions correctly, but the full new paper indexing flow wasn't completely verified due to browser interaction challenges

**Session details**: Requested by Saeejith Nair (@saeejithnair) - [Devin session link](https://app.devin.ai/sessions/0bffba25c6a34756ba104bba829d0534)